### PR TITLE
Convert from `Amount` to `Cost`

### DIFF
--- a/grocerytracker.xcodeproj/project.pbxproj
+++ b/grocerytracker.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		31AEFCD52C7D4C450076AE8D /* ProductCategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCD42C7D4C450076AE8D /* ProductCategoryDetailView.swift */; };
 		31AEFCD72C7D4C740076AE8D /* AddProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCD62C7D4C740076AE8D /* AddProductView.swift */; };
 		31AEFCDD2C8CC59D0076AE8D /* PriceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCDC2C8CC59D0076AE8D /* PriceHelper.swift */; };
-		31AEFCDF2C8CC89D0076AE8D /* Amount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCDE2C8CC89D0076AE8D /* Amount.swift */; };
+		31AEFCDF2C8CC89D0076AE8D /* Cost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCDE2C8CC89D0076AE8D /* Cost.swift */; };
 		31AEFCEE2C90F3B00076AE8D /* PriceHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCED2C90F3B00076AE8D /* PriceHelperTests.swift */; };
 		31AEFCF02C938D500076AE8D /* ProductDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEFCEF2C938D500076AE8D /* ProductDetailView.swift */; };
 		31F2A86A2C6D69B000B7B494 /* grocerytrackerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F2A8692C6D69B000B7B494 /* grocerytrackerApp.swift */; };
@@ -35,7 +35,7 @@
 		31AEFCD42C7D4C450076AE8D /* ProductCategoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryDetailView.swift; sourceTree = "<group>"; };
 		31AEFCD62C7D4C740076AE8D /* AddProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductView.swift; sourceTree = "<group>"; };
 		31AEFCDC2C8CC59D0076AE8D /* PriceHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceHelper.swift; sourceTree = "<group>"; };
-		31AEFCDE2C8CC89D0076AE8D /* Amount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amount.swift; sourceTree = "<group>"; };
+		31AEFCDE2C8CC89D0076AE8D /* Cost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cost.swift; sourceTree = "<group>"; };
 		31AEFCE42C90F3280076AE8D /* grocerytrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = grocerytrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		31AEFCED2C90F3B00076AE8D /* PriceHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceHelperTests.swift; sourceTree = "<group>"; };
 		31AEFCEF2C938D500076AE8D /* ProductDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailView.swift; sourceTree = "<group>"; };
@@ -101,7 +101,7 @@
 				31AEFCEF2C938D500076AE8D /* ProductDetailView.swift */,
 				31AEFCD62C7D4C740076AE8D /* AddProductView.swift */,
 				31AEFCDC2C8CC59D0076AE8D /* PriceHelper.swift */,
-				31AEFCDE2C8CC89D0076AE8D /* Amount.swift */,
+				31AEFCDE2C8CC89D0076AE8D /* Cost.swift */,
 				31F2A8772C6D811800B7B494 /* GroceryTracker.xcdatamodeld */,
 				31F2A87A2C6D81B100B7B494 /* DataController.swift */,
 				31F2A86D2C6D69B100B7B494 /* Assets.xcassets */,
@@ -229,7 +229,7 @@
 				31F2A86C2C6D69B000B7B494 /* GroceryView.swift in Sources */,
 				31AEFCD52C7D4C450076AE8D /* ProductCategoryDetailView.swift in Sources */,
 				31F2A87B2C6D81B100B7B494 /* DataController.swift in Sources */,
-				31AEFCDF2C8CC89D0076AE8D /* Amount.swift in Sources */,
+				31AEFCDF2C8CC89D0076AE8D /* Cost.swift in Sources */,
 				31F2A8792C6D811800B7B494 /* GroceryTracker.xcdatamodeld in Sources */,
 				31AEFCD72C7D4C740076AE8D /* AddProductView.swift in Sources */,
 				31F2A86A2C6D69B000B7B494 /* grocerytrackerApp.swift in Sources */,

--- a/grocerytracker/AddProductView.swift
+++ b/grocerytracker/AddProductView.swift
@@ -98,10 +98,8 @@ struct AddProductView: View {
                             // Create new product within existing category
                             let newProduct = Product(context: moc)
                             newProduct.id = UUID()
-                            newProduct.price = price
                             newProduct.cost = Cost(price: price, quantity: quantity, unit: unit)
                             newProduct.store = $store.wrappedValue
-                            newProduct.salePrice = salePrice
                             newProduct.brand = brand.isEmpty ? nil : brand
                             newProduct.lastUpdated = Date()
 
@@ -118,10 +116,8 @@ struct AddProductView: View {
                             let newProduct = Product(context: moc)
 
                             newProduct.id = UUID()
-                            newProduct.price = price
                             newProduct.cost = Cost(price: price, quantity: quantity, unit: unit)
                             newProduct.store = $store.wrappedValue
-                            newProduct.salePrice = salePrice
                             newProduct.brand = brand.isEmpty ? nil : brand
                             newProduct.lastUpdated = Date()
 

--- a/grocerytracker/AddProductView.swift
+++ b/grocerytracker/AddProductView.swift
@@ -22,7 +22,7 @@ struct AddProductView: View {
     @State private var productName = ""
     @State private var price: Double = 0.0
     @State private var quantity: Double = 0.0
-    @State private var unit: Amount.Unit = .unit
+    @State private var unit: Cost.Unit = .unit
     @State private var store: String = "Fresh St. Market"
     
     // Optional Properties
@@ -57,7 +57,7 @@ struct AddProductView: View {
                             .keyboardType(.decimalPad)
                             .multilineTextAlignment(.trailing)
                         Picker("", selection: $unit) {
-                            ForEach(Amount.Unit.allCases) { option in
+                            ForEach(Cost.Unit.allCases) { option in
                                 Text(option.rawValue)
                             }
                         }
@@ -99,10 +99,10 @@ struct AddProductView: View {
                             let newProduct = Product(context: moc)
                             newProduct.id = UUID()
                             newProduct.price = price
-                            newProduct.amount = Amount(quantity: quantity, unit: unit)
+                            newProduct.cost = Cost(price: price, quantity: quantity, unit: unit)
                             newProduct.store = $store.wrappedValue
                             newProduct.salePrice = salePrice
-                            newProduct.brand = brand
+                            newProduct.brand = brand.isEmpty ? nil : brand
                             newProduct.lastUpdated = Date()
 
                             var products = existingCategory.products?.allObjects ?? []
@@ -116,12 +116,13 @@ struct AddProductView: View {
                             newCategory.name = productName
 
                             let newProduct = Product(context: moc)
+
                             newProduct.id = UUID()
                             newProduct.price = price
-                            newProduct.amount = Amount(quantity: quantity, unit: unit)
+                            newProduct.cost = Cost(price: price, quantity: quantity, unit: unit)
                             newProduct.store = $store.wrappedValue
                             newProduct.salePrice = salePrice
-                            newProduct.brand = brand
+                            newProduct.brand = brand.isEmpty ? nil : brand
                             newProduct.lastUpdated = Date()
 
                             newCategory.products = NSSet(array: [newProduct])

--- a/grocerytracker/Cost.swift
+++ b/grocerytracker/Cost.swift
@@ -1,5 +1,5 @@
 //
-//  Amount.swift
+//  Cost.swift
 //  grocerytracker
 //
 //  Created by Elisa Kazan on 2024-09-07.
@@ -7,17 +7,23 @@
 
 import Foundation
 
-@objc(Amount)
-public class Amount: NSObject, NSSecureCoding {
+@objc(Cost)
+public class Cost: NSObject, NSSecureCoding {
+    public var price: Double
     public var quantity: Double
     public var unit: Unit
 
-    init(quantity: Double, unit: Unit) {
+    init(price: Double, quantity: Double, unit: Unit) {
+        self.price = price
         self.quantity = quantity
         self.unit = unit
     }
 
     public override var description: String {
+        "Cost: \(price), \(quantity), \(unit)"
+    }
+
+    public var amountDescription: String {
         "\(quantity) \(unit)"
     }
 
@@ -38,36 +44,39 @@ public class Amount: NSObject, NSSecureCoding {
     // NSCoding
 
     private enum CodingKeys: String {
+        case price
         case quantity
         case unit
     }
 
     public required init?(coder: NSCoder) {
+        price = coder.decodeDouble(forKey: CodingKeys.price.rawValue)
         quantity = coder.decodeDouble(forKey: CodingKeys.quantity.rawValue)
-        let unitRawValue = coder.decodeObject(of: [Amount.self, NSString.self], forKey: CodingKeys.unit.rawValue) as? String ?? "unit"
+        let unitRawValue = coder.decodeObject(of: [Cost.self, NSString.self], forKey: CodingKeys.unit.rawValue) as? String ?? "unit"
         unit = Unit(rawValue: unitRawValue) ?? .unit
     }
 
     public func encode(with coder: NSCoder) {
-        coder.encode(quantity, forKey: "quantity")
-        coder.encode(unit.rawValue, forKey: "unit")
+        coder.encode(price, forKey: CodingKeys.price.rawValue)
+        coder.encode(quantity, forKey: CodingKeys.quantity.rawValue)
+        coder.encode(unit.rawValue, forKey: CodingKeys.unit.rawValue)
     }
 
     // NSSecureCoding
     public static var supportsSecureCoding: Bool = true
 }
 
-@objc(AmountTransformer)
-public class AmountTransformer: ValueTransformer {
+@objc(CostTransformer)
+public class CostTransformer: ValueTransformer {
 
     override public func transformedValue(_ value: Any?) -> Any? {
-        guard let amount = value as? Amount else { return nil }
+        guard let cost = value as? Cost else { return nil }
 
         do {
-            let data = try NSKeyedArchiver.archivedData(withRootObject: amount, requiringSecureCoding: true)
+            let data = try NSKeyedArchiver.archivedData(withRootObject: cost, requiringSecureCoding: true)
             return data
         } catch {
-            assertionFailure("Failed to transform `Amount` to `Data`")
+            assertionFailure("Failed to transform `Cost` to `Data`")
             return nil
         }
     }
@@ -76,16 +85,16 @@ public class AmountTransformer: ValueTransformer {
         guard let data = value as? NSData else { return nil }
 
         do {
-            let amount = try NSKeyedUnarchiver.unarchivedObject(ofClass: Amount.self, from: data as Data)
-            return amount
+            let cost = try NSKeyedUnarchiver.unarchivedObject(ofClass: Cost.self, from: data as Data)
+            return cost
         } catch {
-            assertionFailure("Failed to transform `Data` to `Amount`")
+            assertionFailure("Failed to transform `Data` to `Cost`")
             return nil
         }
     }
 
     override public class func transformedValueClass() -> AnyClass {
-        return Amount.self
+        return Cost.self
     }
 
     override public class func allowsReverseTransformation() -> Bool {

--- a/grocerytracker/GroceryTracker.xcdatamodeld/GroceryTracker.xcdatamodel/contents
+++ b/grocerytracker/GroceryTracker.xcdatamodeld/GroceryTracker.xcdatamodel/contents
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="Product" representedClassName="Product" syncable="YES" codeGenerationType="class">
-        <attribute name="amount" optional="YES" attributeType="Transformable" valueTransformerName="AmountTransformer" customClassName="Amount"/>
         <attribute name="brand" optional="YES" attributeType="String"/>
+        <attribute name="cost" optional="YES" attributeType="Transformable" valueTransformerName="CostTransformer" customClassName="Cost"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>

--- a/grocerytracker/GroceryTracker.xcdatamodeld/GroceryTracker.xcdatamodel/contents
+++ b/grocerytracker/GroceryTracker.xcdatamodeld/GroceryTracker.xcdatamodel/contents
@@ -6,8 +6,6 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="salePrice" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="store" optional="YES" attributeType="String"/>
         <relationship name="category" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="products" inverseEntity="ProductCategory"/>
     </entity>

--- a/grocerytracker/PriceHelper.swift
+++ b/grocerytracker/PriceHelper.swift
@@ -25,32 +25,32 @@ public class PriceHelper {
     // Calculates the price per unit given price and amount
     // If g or ml, price will be per 100 units (i.e. 100 ml)
     // If kg, l or unit, price will be per single unit (i.e. 1 kg)
-//    public func pricePerUnit(price: Double, amount: Amount) -> (Double, Amount) {
-//        let pricePerUnit: Double
-//        let quantity: Double
-//
-//        switch amount.unit {
-//        case .milliliter, .gram:
-//            pricePerUnit = (price / amount.quantity) * 100
-//            quantity = 100
-//        case .litre, .kilogram, .unit:
-//            pricePerUnit = price / amount.quantity
-//            quantity = 1
-//        }
-//
-//        return (pricePerUnit, Amount(quantity: quantity, unit: amount.unit))
-//    }
+    public func pricePerUnit(cost: Cost) -> Cost {
+        let pricePerUnit: Double
+        let quantity: Double
+
+        switch cost.unit {
+        case .milliliter, .gram:
+            pricePerUnit = (cost.price / cost.quantity) * 100
+            quantity = 100
+        case .litre, .kilogram, .unit:
+            pricePerUnit = cost.price / cost.quantity
+            quantity = 1
+        }
+
+        return Cost(price: pricePerUnit, quantity: quantity, unit: cost.unit)
+    }
 
     // String representation of price per unit
-//    public func prettyPricePerUnit(price: Double, amount: Amount) -> String {
-//        let prettyPrice = priceFormatter.string(for: price)!
-//        let prettyQuantity = NumberFormatter().string(for: amount.quantity)!
-//
-//        if amount.quantity == 1 {
-//            // No need to show quantity (ex: "$10 / kg")
-//            return "\(prettyPrice) / \(amount.unit.rawValue)"
-//        } else {
-//            return "\(prettyPrice) / \(prettyQuantity) \(amount.unit.rawValue)"
-//        }
-//    }
+    public func prettyPricePerUnit(cost: Cost) -> String {
+        let prettyPrice = priceFormatter.string(for: cost.price)!
+        let prettyQuantity = NumberFormatter().string(for: cost.quantity)!
+
+        if cost.quantity == 1 {
+            // No need to show quantity (ex: "$10 / kg")
+            return "\(prettyPrice) / \(cost.unit.rawValue)"
+        } else {
+            return "\(prettyPrice) / \(prettyQuantity) \(cost.unit.rawValue)"
+        }
+    }
 }

--- a/grocerytracker/PriceHelper.swift
+++ b/grocerytracker/PriceHelper.swift
@@ -25,32 +25,32 @@ public class PriceHelper {
     // Calculates the price per unit given price and amount
     // If g or ml, price will be per 100 units (i.e. 100 ml)
     // If kg, l or unit, price will be per single unit (i.e. 1 kg)
-    public func pricePerUnit(price: Double, amount: Amount) -> (Double, Amount) {
-        let pricePerUnit: Double
-        let quantity: Double
-
-        switch amount.unit {
-        case .milliliter, .gram:
-            pricePerUnit = (price / amount.quantity) * 100
-            quantity = 100
-        case .litre, .kilogram, .unit:
-            pricePerUnit = price / amount.quantity
-            quantity = 1
-        }
-
-        return (pricePerUnit, Amount(quantity: quantity, unit: amount.unit))
-    }
+//    public func pricePerUnit(price: Double, amount: Amount) -> (Double, Amount) {
+//        let pricePerUnit: Double
+//        let quantity: Double
+//
+//        switch amount.unit {
+//        case .milliliter, .gram:
+//            pricePerUnit = (price / amount.quantity) * 100
+//            quantity = 100
+//        case .litre, .kilogram, .unit:
+//            pricePerUnit = price / amount.quantity
+//            quantity = 1
+//        }
+//
+//        return (pricePerUnit, Amount(quantity: quantity, unit: amount.unit))
+//    }
 
     // String representation of price per unit
-    public func prettyPricePerUnit(price: Double, amount: Amount) -> String {
-        let prettyPrice = priceFormatter.string(for: price)!
-        let prettyQuantity = NumberFormatter().string(for: amount.quantity)!
-
-        if amount.quantity == 1 {
-            // No need to show quantity (ex: "$10 / kg")
-            return "\(prettyPrice) / \(amount.unit.rawValue)"
-        } else {
-            return "\(prettyPrice) / \(prettyQuantity) \(amount.unit.rawValue)"
-        }
-    }
+//    public func prettyPricePerUnit(price: Double, amount: Amount) -> String {
+//        let prettyPrice = priceFormatter.string(for: price)!
+//        let prettyQuantity = NumberFormatter().string(for: amount.quantity)!
+//
+//        if amount.quantity == 1 {
+//            // No need to show quantity (ex: "$10 / kg")
+//            return "\(prettyPrice) / \(amount.unit.rawValue)"
+//        } else {
+//            return "\(prettyPrice) / \(prettyQuantity) \(amount.unit.rawValue)"
+//        }
+//    }
 }

--- a/grocerytracker/ProductCategoryDetailView.swift
+++ b/grocerytracker/ProductCategoryDetailView.swift
@@ -34,11 +34,12 @@ struct ProductCategoryDetailView: View {
                         HStack {
                             Text(product.store ?? "Unknown Store")
                             VStack {
-                                Text(priceHelper.prettyPricePerUnit(price: product.price, amount: product.amount!))
-                                    .font(.headline)
-                                let pricePerUnit = priceHelper.pricePerUnit(price: product.price, amount: product.amount!)
-                                Text("(\(priceHelper.prettyPricePerUnit(price: pricePerUnit.0, amount: pricePerUnit.1)))")
-                                    .font(.subheadline)
+                                Text("coming soon...")
+//                                Text(priceHelper.prettyPricePerUnit(price: product.price, amount: product.amount!))
+//                                    .font(.headline)
+//                                let pricePerUnit = priceHelper.pricePerUnit(price: product.price, amount: product.amount!)
+//                                Text("(\(priceHelper.prettyPricePerUnit(price: pricePerUnit.0, amount: pricePerUnit.1)))")
+//                                    .font(.subheadline)
                             }
                         }
                     }

--- a/grocerytracker/ProductCategoryDetailView.swift
+++ b/grocerytracker/ProductCategoryDetailView.swift
@@ -34,12 +34,11 @@ struct ProductCategoryDetailView: View {
                         HStack {
                             Text(product.store ?? "Unknown Store")
                             VStack {
-                                Text("coming soon...")
-//                                Text(priceHelper.prettyPricePerUnit(price: product.price, amount: product.amount!))
-//                                    .font(.headline)
-//                                let pricePerUnit = priceHelper.pricePerUnit(price: product.price, amount: product.amount!)
-//                                Text("(\(priceHelper.prettyPricePerUnit(price: pricePerUnit.0, amount: pricePerUnit.1)))")
-//                                    .font(.subheadline)
+                                Text(priceHelper.prettyPricePerUnit(cost: product.cost!))
+                                    .font(.headline)
+                                let pricePerUnit = priceHelper.pricePerUnit(cost: product.cost!)
+                                Text("(\(priceHelper.prettyPricePerUnit(cost: pricePerUnit))")
+                                    .font(.subheadline)
                             }
                         }
                     }

--- a/grocerytracker/ProductDetailView.swift
+++ b/grocerytracker/ProductDetailView.swift
@@ -23,7 +23,7 @@ struct ProductDetailView: View {
         Text(name).font(.title)
         HStack {
             Text("Price:")
-            Text(priceHelper.priceFormatter.string(from: product.price as NSNumber)!)
+            Text(priceHelper.priceFormatter.string(from: product.cost!.price as NSNumber)!)
         }
 
         HStack {
@@ -43,12 +43,6 @@ struct ProductDetailView: View {
         HStack {
             Text("Store:")
             Text(product.store ?? "Unknown Store")
-        }
-
-        HStack {
-            Text("Sale Price:")
-            let priceToDisplay = product.salePrice > 0 ? priceHelper.priceFormatter.string(from: product.salePrice as NSNumber)! : "Unknown Sale Price"
-            Text(priceToDisplay)
         }
 
         HStack {

--- a/grocerytracker/ProductDetailView.swift
+++ b/grocerytracker/ProductDetailView.swift
@@ -28,30 +28,32 @@ struct ProductDetailView: View {
 
         HStack {
             Text("Amount:")
-            Text(product.amount?.description ?? "Unknown Amount")
+            Text(product.cost?.amountDescription ?? "Unknown Amount")
         }
 
         HStack {
             Text("Price Per Unit:")
-            let pricePerUnit: (Double, Amount) = priceHelper.pricePerUnit(price: product.price, amount: product.amount!)
-            let prettyPPU = priceHelper.prettyPricePerUnit(price: pricePerUnit.0, amount: pricePerUnit.1)
-            Text(prettyPPU)
+            // TODO: Update this 
+//            let pricePerUnit: (Double, Amount) = priceHelper.pricePerUnit(price: product.price, amount: product.amount!)
+//            let prettyPPU = priceHelper.prettyPricePerUnit(price: pricePerUnit.0, amount: pricePerUnit.1)
+//            Text(prettyPPU)
+            Text("coming soon...")
         }
 
         HStack {
             Text("Store:")
-            Text(product.store ?? "Unknown")
+            Text(product.store ?? "Unknown Store")
         }
 
         HStack {
             Text("Sale Price:")
-            let priceToDisplay = product.salePrice > 0 ? priceHelper.priceFormatter.string(from: product.salePrice as NSNumber)! : "Unknown"
+            let priceToDisplay = product.salePrice > 0 ? priceHelper.priceFormatter.string(from: product.salePrice as NSNumber)! : "Unknown Sale Price"
             Text(priceToDisplay)
         }
 
         HStack {
             Text("Brand:")
-            Text(product.brand ?? "Unknown")
+            Text(product.brand ?? "Unknown Brand")
         }
 
         HStack {

--- a/grocerytracker/ProductDetailView.swift
+++ b/grocerytracker/ProductDetailView.swift
@@ -33,11 +33,8 @@ struct ProductDetailView: View {
 
         HStack {
             Text("Price Per Unit:")
-            // TODO: Update this 
-//            let pricePerUnit: (Double, Amount) = priceHelper.pricePerUnit(price: product.price, amount: product.amount!)
-//            let prettyPPU = priceHelper.prettyPricePerUnit(price: pricePerUnit.0, amount: pricePerUnit.1)
-//            Text(prettyPPU)
-            Text("coming soon...")
+            let pricePerUnit = priceHelper.pricePerUnit(cost: product.cost!)
+            Text(priceHelper.prettyPricePerUnit(cost: pricePerUnit))
         }
 
         HStack {

--- a/grocerytrackerTests/PriceHelperTests.swift
+++ b/grocerytrackerTests/PriceHelperTests.swift
@@ -14,142 +14,117 @@ final class PriceHelperTests: XCTestCase {
 
     func testPricePerUnitKilogram() {
         let priceHelper = PriceHelper()
-
-        let price = 12.99
-        let amount = Amount(quantity: 1.81, unit: .kilogram)
+        let cost = Cost(price: 12.99, quantity: 1.81, unit: .kilogram)
 
         let expectedPrice = 7.176795580110497
         let expectedQuanity = 1.0
-        let expectedUnit = Amount.Unit.kilogram
+        let expectedUnit = Cost.Unit.kilogram
 
-        let pricePerUnit = priceHelper.pricePerUnit(price: price, amount: amount)
+        let pricePerUnit = priceHelper.pricePerUnit(cost: cost)
 
-        XCTAssertEqual(pricePerUnit.0, expectedPrice)
-        XCTAssertEqual(pricePerUnit.1.quantity, expectedQuanity)
-        XCTAssertEqual(pricePerUnit.1.unit, expectedUnit)
+        XCTAssertEqual(pricePerUnit.price, expectedPrice)
+        XCTAssertEqual(pricePerUnit.quantity, expectedQuanity)
+        XCTAssertEqual(pricePerUnit.unit, expectedUnit)
     }
 
     func testPricePerUnitGram() {
         let priceHelper = PriceHelper()
-
-        let price = 10.89
-        let amount = Amount(quantity: 700, unit: .gram)
+        let cost = Cost(price: 10.89, quantity: 700, unit: .gram)
 
         let expectedPrice = 1.5557142857142858
         let expectedQuanity = 100.0
-        let expectedUnit = Amount.Unit.gram
+        let expectedUnit = Cost.Unit.gram
 
-        let pricePerUnit = priceHelper.pricePerUnit(price: price, amount: amount)
+        let pricePerUnit = priceHelper.pricePerUnit(cost: cost)
 
-        XCTAssertEqual(pricePerUnit.0, expectedPrice)
-        XCTAssertEqual(pricePerUnit.1.quantity, expectedQuanity)
-        XCTAssertEqual(pricePerUnit.1.unit, expectedUnit)
+        XCTAssertEqual(pricePerUnit.price, expectedPrice)
+        XCTAssertEqual(pricePerUnit.quantity, expectedQuanity)
+        XCTAssertEqual(pricePerUnit.unit, expectedUnit)
     }
 
     func testPricePerUnitLitre() {
         let priceHelper = PriceHelper()
-
-        let price = 5.99
-        let amount = Amount(quantity: 1.9, unit: .litre)
+        let cost = Cost(price: 5.99, quantity: 1.9, unit: .litre)
 
         let expectedPrice = 3.1526315789473687
         let expectedQuanity = 1.0
-        let expectedUnit = Amount.Unit.litre
+        let expectedUnit = Cost.Unit.litre
 
-        let pricePerUnit = priceHelper.pricePerUnit(price: price, amount: amount)
+        let pricePerUnit = priceHelper.pricePerUnit(cost: cost)
 
-        XCTAssertEqual(pricePerUnit.0, expectedPrice)
-        XCTAssertEqual(pricePerUnit.1.quantity, expectedQuanity)
-        XCTAssertEqual(pricePerUnit.1.unit, expectedUnit)
+        XCTAssertEqual(pricePerUnit.price, expectedPrice)
+        XCTAssertEqual(pricePerUnit.quantity, expectedQuanity)
+        XCTAssertEqual(pricePerUnit.unit, expectedUnit)
     }
 
     func testPricePerUnitMillillitre() {
         let priceHelper = PriceHelper()
-
-        let price = 16.99
-        let amount = Amount(quantity: 473, unit: .milliliter)
+        let cost = Cost(price: 16.99, quantity: 473, unit: .milliliter)
 
         let expectedPrice = 3.591966173361522
         let expectedQuanity = 100.0
-        let expectedUnit = Amount.Unit.milliliter
+        let expectedUnit = Cost.Unit.milliliter
 
-        let pricePerUnit = priceHelper.pricePerUnit(price: price, amount: amount)
+        let pricePerUnit = priceHelper.pricePerUnit(cost: cost)
 
-        XCTAssertEqual(pricePerUnit.0, expectedPrice)
-        XCTAssertEqual(pricePerUnit.1.quantity, expectedQuanity)
-        XCTAssertEqual(pricePerUnit.1.unit, expectedUnit)
+        XCTAssertEqual(pricePerUnit.price, expectedPrice)
+        XCTAssertEqual(pricePerUnit.quantity, expectedQuanity)
+        XCTAssertEqual(pricePerUnit.unit, expectedUnit)
     }
 
     func testPricePerUnitUnit() {
         let priceHelper = PriceHelper()
-
-        let price = 39.99
-        let amount = Amount(quantity: 30, unit: .unit)
+        let cost = Cost(price: 39.99, quantity: 30, unit: .unit)
 
         let expectedPrice = 1.333
         let expectedQuanity = 1.0
-        let expectedUnit = Amount.Unit.unit
+        let expectedUnit = Cost.Unit.unit
 
-        let pricePerUnit = priceHelper.pricePerUnit(price: price, amount: amount)
+        let pricePerUnit = priceHelper.pricePerUnit(cost: cost)
 
-        XCTAssertEqual(pricePerUnit.0, expectedPrice)
-        XCTAssertEqual(pricePerUnit.1.quantity, expectedQuanity)
-        XCTAssertEqual(pricePerUnit.1.unit, expectedUnit)
+        XCTAssertEqual(pricePerUnit.price, expectedPrice)
+        XCTAssertEqual(pricePerUnit.quantity, expectedQuanity)
+        XCTAssertEqual(pricePerUnit.unit, expectedUnit)
     }
 
     // MARK: - Pretty Price Per Unit
 
     func testPrettyPricePerUnitKilogram() {
         let priceHelper = PriceHelper()
-
-        let price = 7.176795580110497
-        let amount = Amount(quantity: 1.0, unit: .kilogram)
-
-        let prettyText = priceHelper.prettyPricePerUnit(price: price, amount: amount)
+        let cost = Cost(price: 7.176795580110497, quantity: 1.0, unit: .kilogram)
+        let prettyText = priceHelper.prettyPricePerUnit(cost: cost)
 
         XCTAssertEqual(prettyText, "$7.18 / kg")
     }
 
     func testPrettyPricePerUnitGram() {
         let priceHelper = PriceHelper()
-
-        let price = 1.5557142857142858
-        let amount = Amount(quantity: 100, unit: .gram)
-
-        let prettyText = priceHelper.prettyPricePerUnit(price: price, amount: amount)
+        let cost = Cost(price: 1.5557142857142858, quantity: 100, unit: .gram)
+        let prettyText = priceHelper.prettyPricePerUnit(cost: cost)
 
         XCTAssertEqual(prettyText, "$1.56 / 100 g")
     }
 
     func testPrettyPricePerUnitLitre() {
         let priceHelper = PriceHelper()
-
-        let price = 3.1526315789473687
-        let amount = Amount(quantity: 1.0, unit: .litre)
-
-        let prettyText = priceHelper.prettyPricePerUnit(price: price, amount: amount)
+        let cost = Cost(price: 3.1526315789473687, quantity: 1.0, unit: .litre)
+        let prettyText = priceHelper.prettyPricePerUnit(cost: cost)
 
         XCTAssertEqual(prettyText, "$3.15 / L")
     }
 
     func testPrettyPricePerUnitMillillitre() {
         let priceHelper = PriceHelper()
-
-        let price = 3.591966173361522
-        let amount = Amount(quantity: 100.0, unit: .milliliter)
-
-        let prettyText = priceHelper.prettyPricePerUnit(price: price, amount: amount)
+        let cost = Cost(price: 3.591966173361522, quantity: 100, unit: .milliliter)
+        let prettyText = priceHelper.prettyPricePerUnit(cost: cost)
 
         XCTAssertEqual(prettyText, "$3.59 / 100 ml")
     }
 
     func testPrettyPricePerUnitUnit() {
         let priceHelper = PriceHelper()
-
-        let price = 1.333
-        let amount = Amount(quantity: 1.0, unit: .unit)
-
-        let prettyText = priceHelper.prettyPricePerUnit(price: price, amount: amount)
+        let cost = Cost(price: 1.333, quantity: 1.0, unit: .unit)
+        let prettyText = priceHelper.prettyPricePerUnit(cost: cost)
 
         XCTAssertEqual(prettyText, "$1.33 / unit")
     }


### PR DESCRIPTION
Fixes #15 

- Converts `Amount` to `Cost`
- Removes `salePrice`
- Updates `pricePerUnit` and `prettyPricePerUnit`