### PR TITLE
Add alert for deleting a product category

### DIFF
--- a/grocerytracker/AddProductView.swift
+++ b/grocerytracker/AddProductView.swift
@@ -21,6 +21,7 @@ struct AddProductView: View {
                         TextField("ex: Milk", text: $viewModel.product.name)
                             .textInputAutocapitalization(.words)
                             .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
                     }
 
                     HStack {

--- a/grocerytracker/GroceryView.swift
+++ b/grocerytracker/GroceryView.swift
@@ -13,6 +13,10 @@ struct GroceryView: View {
 
     @State private var showingAddNewProduct = false
 
+    // Delete a category with alert
+    @State private var showingDeleteAlert = false
+    @State private var deletedIndexSet: IndexSet = IndexSet()
+
     @State private var searchText = ""
 
     private let priceHelper = PriceHelper()
@@ -35,8 +39,20 @@ struct GroceryView: View {
                         }
                     }
                 }
-                .onDelete(perform: removeCategory)
+                .onDelete { indexSet in
+                    deletedIndexSet = indexSet
+                    showingDeleteAlert = true
+                }
             }
+            .alert("Are you sure you want to delete this product?", isPresented: $showingDeleteAlert, actions: {
+                Button("Yes") {
+                    removeCategory(at: deletedIndexSet)
+                    deletedIndexSet = IndexSet()
+                }
+                Button("Cancel") {
+                    deletedIndexSet = IndexSet()
+                }
+            })
             .navigationTitle("Grocery Tracker")
             .searchable(text: $searchText, prompt: "Search for a product")
             .onChange(of: searchText) { _, newSearch in
@@ -61,7 +77,6 @@ struct GroceryView: View {
     }
 
     func removeCategory(at offsets: IndexSet) {
-        // TODO: Add confirmation dialog because this will also delete all products in the category as well
         for index in offsets {
             let categoryToRemove = categories[index]
             moc.delete(categoryToRemove)

--- a/grocerytracker/GroceryView.swift
+++ b/grocerytracker/GroceryView.swift
@@ -45,11 +45,11 @@ struct GroceryView: View {
                 }
             }
             .alert("Are you sure you want to delete this product?", isPresented: $showingDeleteAlert, actions: {
-                Button("Yes") {
+                Button("Yes", role: .destructive) {
                     removeCategory(at: deletedIndexSet)
                     deletedIndexSet = IndexSet()
                 }
-                Button("Cancel") {
+                Button("Cancel", role: .cancel) {
                     deletedIndexSet = IndexSet()
                 }
             })


### PR DESCRIPTION
Added an alert dialog when deleting a product category. This gives us an extra layer of protection since it will also delete all of the products in the category.

### Screenshots
<img src="https://github.com/user-attachments/assets/8f4e95aa-d868-4c15-a452-0d628c86139e"  width="200" />

Tried a Confirmation Dialog but didn't like how it looked.

<img src="https://github.com/user-attachments/assets/9154b8ea-1e85-44a9-a63f-49cc8f27801d"  width="200" />
